### PR TITLE
xmerl_c14n:canon_name/3 fix.

### DIFF
--- a/src/xmerl_c14n.erl
+++ b/src/xmerl_c14n.erl
@@ -24,11 +24,15 @@ canon_name(Ns, Name, Nsp) ->
          case proplists:get_value(Ns, Nsp#xmlNamespace.nodes) of
             undefined ->
                error({ns_not_found, Ns, Nsp});
-            Uri -> atom_to_list(Uri)
+            Uri -> Uri
          end
    end,
-   NamePart = if is_atom(Name) -> atom_to_list(Name); true -> Name end,
-   lists:flatten([NsPart | NamePart]).
+   IfAtom2List =
+        fun
+            (N) when is_atom(N) -> atom_to_list(N);
+            (N)                 -> N
+        end,
+   lists:flatten([IfAtom2List(NsPart) | IfAtom2List(Name)]).
 
 %% @doc Returns the canonical URI name of an XML element or attribute.
 %% @internal


### PR DESCRIPTION
We got somthing like ['http://www.w3.org/2000/09/xmldsig#',"Signature"] when
default namespace was used.

I observed this error when started my integration with centrify service.
This was reason why signature element was not stripped correctly.
example of xml:
https://gist.github.com/IgorKarymov/6776658
