### PR TITLE
Public_Key 0.23 vs 1.0, i.e. Erlang/OTP 18 incompatibilities

### DIFF
--- a/src/esaml_util.erl
+++ b/src/esaml_util.erl
@@ -139,8 +139,10 @@ load_private_key(Path) ->
             {ok, KeyFile} = file:read_file(Path),
             [KeyEntry] = public_key:pem_decode(KeyFile),
             Key = case public_key:pem_entry_decode(KeyEntry) of
-                #'PrivateKeyInfo'{privateKey = KeyData} ->
+                #'PrivateKeyInfo'{privateKey = KeyData} when is_list(KeyData) ->
                     public_key:der_decode('RSAPrivateKey', list_to_binary(KeyData));
+                #'PrivateKeyInfo'{privateKey = KeyData} when is_binary(KeyData) ->
+                    public_key:der_decode('RSAPrivateKey', KeyData);
                 Other -> Other
             end,
             ets:insert(esaml_privkey_cache, {Path, Key}),

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -201,7 +201,10 @@ verify(Element, Fingerprints) ->
         CertHash2 = crypto:hash(sha256, CertBin),
 
         Cert = public_key:pkix_decode_cert(CertBin, plain),
-        {_, KeyBin} = Cert#'Certificate'.tbsCertificate#'TBSCertificate'.subjectPublicKeyInfo#'SubjectPublicKeyInfo'.subjectPublicKey,
+        KeyBin = case Cert#'Certificate'.tbsCertificate#'TBSCertificate'.subjectPublicKeyInfo#'SubjectPublicKeyInfo'.subjectPublicKey of
+            {_, KeyBin2} -> KeyBin2; % Public_Key 0.23
+            KeyBin2 -> KeyBin2 % Public_Key 1.0, i.e. Erlang/OTP 18
+        end,
         Key = public_key:pem_entry_decode({'RSAPublicKey', KeyBin, not_encrypted}),
 
         case public_key:verify(Data, HashFunction, Sig, Key) of


### PR DESCRIPTION
This adds compatibility with Public_Key 1.0, i.e. Erlang/OTP 18, ERTS 7.0. There might be more to fix, the docs are hard to compare. S.a. 
http://www.erlang.org/doc/apps/public_key/notes.html
http://www.erlang.org/documentation/doc-6.4/lib/public_key-0.23/doc/html/public_key.html
http://www.erlang.org/documentation/doc-7.0/lib/public_key-1.0/doc/html/public_key.html
http://www.erlang.org/documentation/doc-6.4/lib/public_key-0.23/doc/html/public_key_records.html
http://www.erlang.org/documentation/doc-7.0/lib/public_key-1.0/doc/html/public_key_records.html
