### PR TITLE
replace erlang-uuid dependency by proper unique xsd:IDs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,4 @@
 {deps, [
-    {uuid, ".*", {git, "git://github.com/avtobiff/erlang-uuid", "HEAD"}},
     {cowboy, ".*", {git, "git://github.com/extend/cowboy", {branch, "1.0.x"}}}
 ]}.
 %%{sub_dirs, ["rel"]}.

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -26,7 +26,7 @@
 add_xml_id(Xml) ->
     Xml#xmlElement{attributes = Xml#xmlElement.attributes ++ [
         #xmlAttribute{name = 'ID',
-            value = uuid:to_string(uuid:uuid1()),
+            value = esaml_util:unique_id(),
             namespace = #xmlNamespace{}}
         ]}.
 

--- a/src/esaml_util.erl
+++ b/src/esaml_util.erl
@@ -19,6 +19,7 @@
 -export([build_nsinfo/2]).
 -export([load_private_key/1, load_certificate_chain/1, load_certificate/1, load_metadata/2, load_metadata/1]).
 -export([convert_fingerprints/1]).
+-export([unique_id/0]).
 
 %% @doc Converts various ascii hex/base64 fingerprint formats to binary
 -spec convert_fingerprints([string() | binary()]) -> [binary()].
@@ -243,6 +244,19 @@ check_dupe_ets(A, Digest) ->
             end, []]),
             ok
     end.
+
+%% @doc Returns a unique xsd:ID string suitable for SAML use.
+-spec unique_id() -> string().
+unique_id() ->
+    <<R:64>> = crypto:rand_bytes(8),
+    T = try
+        erlang:system_time() % needs ERTS-7.0
+    catch
+        error:undef ->
+            {Mega, Sec, Micro} = erlang:now(),
+            Mega * 1000000 * 1000000 + Sec * 1000000 + Micro
+    end,
+    lists:flatten(io_lib:format("_~.16b~.16b", [R, T])).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -69,7 +69,7 @@ sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_bin
             case lists:keyfind('id', 2, ElementStrip#xmlElement.attributes) of
                 #xmlAttribute{value = LowId} -> {ElementStrip, LowId};
                 _ ->
-                    NewId = uuid:to_string(uuid:uuid1()),
+                    NewId = esaml_util:unique_id(),
                     Attr = #xmlAttribute{name = 'ID', value = NewId, namespace = #xmlNamespace{}},
                     NewAttrs = [Attr | ElementStrip#xmlElement.attributes],
                     Elem = ElementStrip#xmlElement{attributes = NewAttrs},


### PR DESCRIPTION
UUIDs are not well suited as XML IDs. An xsd:ID value must be an NCName, i.e. it must start with a letter or underscore.
We should prepend some character(s).

The only requirement form the SAML specs is uniqueness with a collision chance of at most 1 in 2^128 and 1 in 2^160 is recommended.
UUID-v1 uses a time value with a 100ns resolution but avtobiff/erlang-uuid has µs granularity only. Even with Erlangs speed it isn't likely to generate two IDs within a µs. On the other hand UUID-v1 is leaking a hardware ID (the MAC-Address).

I'd like to propose dropping the dependency on a UUID lib and come up with better IDs. (Incidentally there is more than one possible dep using the "uuid" namespace, which is a nuisance.)

Using a guaranteed unique integer and the hashed node id for universal uniqueness is an idea.
`[erlang:phash2(node()), erlang:unique_integer]`

This would leak some node identifier and the system load though. We might want to just hash both values to get a randomized output. This will weaken the uniqueness and in the best case be equivalent to plain random bytes then.

Using monotonic_time() should be better. It is most likely nano second resolution and in any case it's the best we get. As to not leak the node startup time we use system_time() which is equivalent to monotonic_time() + time_offset().
I'm also adding in a few random bytes to make the ID universally unique with a collision chance of 2^64 for IDs issued at the exact same nano second!
