### PR TITLE
fix c14n canonization

### DIFF
--- a/src/xmerl_c14n.erl
+++ b/src/xmerl_c14n.erl
@@ -181,7 +181,10 @@ c14n(#xmlAttribute{nsinfo = NsInfo, name = Name, value = Value}, _KnownNs, Activ
 
 c14n(Elem = #xmlElement{}, KnownNSIn, ActiveNSIn, Comments, InclNs, Acc) ->
     Namespace = Elem#xmlElement.namespace,
-    Default = Namespace#xmlNamespace.default,
+    Default = case Elem#xmlElement.nsinfo of
+        [] -> Namespace#xmlNamespace.default;
+        _ -> [] % omit a default namespace if it is not visibly utilized.
+    end,
     {ActiveNS, ParentDefault} = case ActiveNSIn of
         [{default, P} | Rest] -> {Rest, P};
         Other -> {Other, ''}
@@ -356,6 +359,12 @@ default_ns_test() ->
 
     Target2 = "<saml2p:Response xmlns:saml2p=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"https://10.10.18.25/saml/consume\" ID=\"_83dbf3f1-53c2-4f49-b294-7c19cbf2b77b\" IssueInstant=\"2013-10-30T11:15:47.517Z\" Version=\"2.0\"><Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_debe5f4e-4343-4f95-b997-89db5a483202\" IssueInstant=\"2013-10-30T11:15:47.517Z\" Version=\"2.0\"><Issuer>foo</Issuer><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\"></NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData NotOnOrAfter=\"2013-10-30T12:15:47.517Z\" Recipient=\"https://10.10.18.25/saml/consume\"></SubjectConfirmationData></SubjectConfirmation></Subject></Assertion></saml2p:Response>",
     Target2 = c14n(Doc2, true).
+
+omit_default_ns_test() ->
+    {Doc, _} = xmerl_scan:string("<foo:a xmlns:foo=\"urn:foo\"><bar:b xmlns=\"urn:bar\" xmlns:bar=\"urn:bar\"><bar:c /></bar:b></foo:a>", [{namespace_conformant, true}]),
+
+    Target = "<foo:a xmlns:foo=\"urn:foo\"><bar:b xmlns:bar=\"urn:bar\"><bar:c></bar:c></bar:b></foo:a>",
+    Target = c14n(Doc, true).
 
 c14n_inclns_test() ->
     {Doc, []} = xmerl_scan:string("<foo:a xmlns:foo=\"urn:foo:\" xmlns:bar=\"urn:bar:\"><foo:b bar:nothing=\"something\">foo</foo:b></foo:a>", [{namespace_conformant, true}]),


### PR DESCRIPTION
omit a default namespace if it is not visibly utilized; the specs suggest that we need to remove even a default namespace, if it is no visibly utilized on the parent. I.e. omit a default ns if the parent is prefixed.
