### PR TITLE
Add name id to generate_authn_request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ebin
 .eunit
+deps

--- a/include/esaml.hrl
+++ b/include/esaml.hrl
@@ -45,7 +45,8 @@
 	issue_instant = "" :: esaml:datetime(),
 	destination = "" :: string(),
 	issuer = "" :: string(),
-	consumer_location = "" :: string()}).
+	consumer_location = "" :: string(),
+	name_id_format :: string() | undefined}).
 
 -record(esaml_subject, {
 	name = "" :: string(),

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -12,7 +12,7 @@
 -include("esaml.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
--export([setup/1, generate_authn_request/2, generate_metadata/1]).
+-export([setup/1, generate_authn_request/3, generate_metadata/1]).
 -export([validate_assertion/2, validate_assertion/3]).
 -export([generate_logout_request/3, generate_logout_response/3]).
 -export([validate_logout_request/2, validate_logout_response/2]).
@@ -31,15 +31,16 @@ add_xml_id(Xml) ->
         ]}.
 
 %% @doc Return an AuthnRequest as an XML element
--spec generate_authn_request(IdpURL :: string(), esaml:sp()) -> #xmlElement{}.
-generate_authn_request(IdpURL, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
+-spec generate_authn_request(IdpURL :: string(), NameIDFormat :: string() | undefined, esaml:sp()) -> #xmlElement{}.
+generate_authn_request(IdpURL, NameIDFormat, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
     Now = erlang:localtime_to_universaltime(erlang:localtime()),
     Stamp = esaml_util:datetime_to_saml(Now),
 
     Xml = esaml:to_xml(#esaml_authnreq{issue_instant = Stamp,
                                        destination = IdpURL,
                                        issuer = MetaURI,
-                                       consumer_location = ConsumeURI}),
+                                       consumer_location = ConsumeURI,
+                                       name_id_format = NameIDFormat}),
     if SP#esaml_sp.sp_sign_requests ->
         xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate);
     true ->


### PR DESCRIPTION
Allows for passed in configuration of name id policy format, to be included in the authn request. 
A format of undefined will generate no name id policy block.
Changes arity of generate_authn_request and removes subject & subject confirmation from xml. 
