### PR TITLE
extract all bindings in esaml:decode_idp_metadata/1

### DIFF
--- a/include/esaml.hrl
+++ b/include/esaml.hrl
@@ -36,7 +36,9 @@
 	signed_requests = true :: boolean(),
 	certificate :: binary() | undefined,
 	entity_id = "" :: string(),
-	login_location = "" :: string(),
+	login_location_post :: string(),
+	login_location_redirect :: string(),
+	login_location_artifact :: string(),
 	logout_location :: string() | undefined,
 	name_format = unknown :: esaml:name_format()}).
 

--- a/test/data/okta_metadata.xml
+++ b/test/data/okta_metadata.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/somehash">
+   <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+      <md:KeyDescriptor use="signing">
+         <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+               <ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAVSraG50MA0GCSqGSIb3DQEBBQUAMIGSMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+MBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi05MTA0OTYxHDAaBgkqhkiG9w0BCQEW
+DWluZm9Ab2t0YS5jb20wHhcNMTYwNTEzMTgzNjA4WhcNMjYwNTEzMTgzNzA4WjCBkjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNV
+BAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtOTEwNDk2MRwwGgYJ
+KoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+3apvyq3Ub0qXCGoeAzy6FgnJdL5bje9WDEAno4nScayedoAHgFMNtKano2OIB+NP4bzVcbo1iiGJ
+K1VW4gpT0Y4bpPVngn6IpSwM9f1j/fNvTvO+PvTlziQAUeeCwoBNXcoEDEacU1x1OL6a3YI/RPvs
+t5hoRfrMkGI220pvwbbY5J3AyeIULQ+d2qtN0LqnmYUxfZ9SS6ADm4VO/qKUKzyBogHt1fZuH5Qa
+EjoCOadKQP9ug1On/lSQ8nExYJBU9n7X8oEkqxPGn1dr59Zul3rmItklacDs9M8/pmetiZzwnXM8
+sWoKzYYLnwhuS213GmH6jD2/e4/2CXntBNBIDwIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQBLw1r3
+8gWoqhxBtyeTlUwzK3iFdni6QyEZTK4A87d540y47l+r/55UGCqV2Y2qnn52UEmge0wq4LBLhcZh
+4XESFILsIkJQqBIWXz6VD35Tu8uqgD6FcGuy/uuTkMyx32+a2KOJBwi8wVMe/O9H8l+mIoLDRhPz
+2CqYNrSQGjy6c7BDURbHNqYemGyYYVaKtF87b6hK98d3MxmnSoTXVHsoI6iNq7475yZaDfwLc6YE
+tKD07rh/537nVWK2YKswxalv+8eQgfxLxYtbyxXNfYiHrp+6GyikFuHNLReweRR1gPamGY5xPmsk
+VO2+XznKZKDxpegJZZyv2YRZHTB3HKzL</ds:X509Certificate>
+            </ds:X509Data>
+         </ds:KeyInfo>
+      </md:KeyDescriptor>
+      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://dev-xxx.okta.com/somehash/sso/saml_post" />
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://dev-xxx.okta.com/somehash/sso/saml_redirect" />
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://dev-xxx.okta.com/somehash/sso/saml_artifact" />
+   </md:IDPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
Before, this would only look for HTTP-POST login locations. Now, it will
extract any location it finds: post, redirect, or artifact. The way this
is achieved is not the most beautiful, but allows for easy matching when
`#esaml_idp_metadata` is used.

Also adds okta-ish test metadata.
