### PR TITLE
Fix deprecation warning, use sha256 for digest

### DIFF
--- a/src/esaml_util.erl
+++ b/src/esaml_util.erl
@@ -253,7 +253,7 @@ unique_id() ->
         erlang:system_time() % needs ERTS-7.0
     catch
         error:undef ->
-            {Mega, Sec, Micro} = erlang:now(),
+            {Mega, Sec, Micro} = erlang:timestamp(),
             Mega * 1000000 * 1000000 + Sec * 1000000 + Micro
     end,
     lists:flatten(io_lib:format("_~.16b~.16b", [R, T])).

--- a/src/esaml_util.erl
+++ b/src/esaml_util.erl
@@ -253,10 +253,17 @@ unique_id() ->
         erlang:system_time() % needs ERTS-7.0
     catch
         error:undef ->
-            {Mega, Sec, Micro} = erlang:timestamp(),
+            {Mega, Sec, Micro} = timestamp(),
             Mega * 1000000 * 1000000 + Sec * 1000000 + Micro
     end,
     lists:flatten(io_lib:format("_~.16b~.16b", [R, T])).
+
+timestamp() ->
+    try
+        erlang:timestamp()
+    catch
+        error:undef -> erlang:now()
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -136,7 +136,7 @@ sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_bin
 %% Strips any XML digital signatures and applies any relevant InclusiveNamespaces
 %% before generating the digest.
 -spec digest(Element :: #xmlElement{}) -> binary().
-digest(Element) -> digest(Element, sha).
+digest(Element) -> digest(Element, sha256).
 
 -spec digest(Element :: #xmlElement{}, HashFunction :: sha | sha256) -> binary().
 digest(Element, HashFunction) ->


### PR DESCRIPTION
- switch to erlang:timestamp() instead of erlang:now() due to deprecation warning
- default to sha256 in xmerl_dsig:digest/1
