### PR TITLE
Bugfix, when trying to implement for Google IDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ebin
 .eunit
+
+.rebar/erlcinfo

--- a/src/esaml.erl
+++ b/src/esaml.erl
@@ -398,10 +398,10 @@ to_xml(#esaml_authnreq{version = V, issue_instant = Time, destination = Dest, is
                       #xmlAttribute{name = 'ProtocolBinding', value = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"}],
         content = [
             #xmlElement{name = 'saml:Issuer', content = [#xmlText{value = Issuer}]},
-            #xmlElement{name = 'samlp:NameIDPolicy', attributes = [#xmlAttribute{name = 'Format', value = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"}]},
-            #xmlElement{name = 'saml:Subject', content = [
-                #xmlElement{name = 'saml:SubjectConfirmation', attributes = [#xmlAttribute{name = 'Method', value = "urn:oasis:names:tc:SAML:2.0:cm:bearer"}]}
-            ]}
+            #xmlElement{name = 'samlp:NameIDPolicy', attributes = [#xmlAttribute{name = 'Format', value = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"}]}
+            % #xmlElement{name = 'saml:Subject', content = [
+            %     #xmlElement{name = 'saml:SubjectConfirmation', attributes = [#xmlAttribute{name = 'Method', value = "urn:oasis:names:tc:SAML:2.0:cm:bearer"}]}
+            % ]}
         ]
     });
 

--- a/src/esaml.erl
+++ b/src/esaml.erl
@@ -398,6 +398,7 @@ to_xml(#esaml_authnreq{version = V, issue_instant = Time, destination = Dest, is
                       #xmlAttribute{name = 'ProtocolBinding', value = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"}],
         content = [
             #xmlElement{name = 'saml:Issuer', content = [#xmlText{value = Issuer}]},
+            #xmlElement{name = 'samlp:NameIDPolicy', attributes = [#xmlAttribute{name = 'Format', value = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"}]},
             #xmlElement{name = 'saml:Subject', content = [
                 #xmlElement{name = 'saml:SubjectConfirmation', attributes = [#xmlAttribute{name = 'Method', value = "urn:oasis:names:tc:SAML:2.0:cm:bearer"}]}
             ]}
@@ -477,7 +478,7 @@ to_xml(#esaml_sp_metadata{org = #esaml_org{name = OrgName, displayname = OrgDisp
                     content = [#xmlElement{name = 'dsig:X509Data',
                         content =
                                 [#xmlElement{name = 'dsig:X509Certificate',
-                            content = [#xmlText{value = base64:encode_to_string(CertBin)}]} | 
+                            content = [#xmlText{value = base64:encode_to_string(CertBin)}]} |
                                 [#xmlElement{name = 'dsig:X509Certificate',
                             content = [#xmlText{value = base64:encode_to_string(CertChainBin)}]} || CertChainBin <- CertChain]]}]}]}]
     end,

--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -39,16 +39,20 @@ xml_payload_type(Xml) ->
 -spec decode_response(SAMLEncoding :: binary(), SAMLResponse :: binary()) -> #xmlDocument{}.
 decode_response(?deflate, SAMLResponse) ->
 	XmlData = binary_to_list(zlib:unzip(base64:decode(SAMLResponse))),
+  erlang:display(XmlData),
 	{Xml, _} = xmerl_scan:string(XmlData, [{namespace_conformant, true}]),
     Xml;
 decode_response(_, SAMLResponse) ->
 	Data = base64:decode(SAMLResponse),
     XmlData = case (catch zlib:unzip(Data)) of
-        {'EXIT', _} -> binary_to_list(Data);
-        Bin -> binary_to_list(Bin)
+        {'EXIT', _} ->
+          binary_to_list(Data);
+        Bin ->
+          binary_to_list(Bin)
     end,
-	{Xml, _} = xmerl_scan:string(XmlData, [{namespace_conformant, true}]),
-    Xml.
+  erlang:display(XmlData),
+  {Xml, _} = xmerl_scan:string(XmlData, [{namespace_conformant, true}]),
+  Xml.
 
 %% @doc Encode a SAMLRequest (or SAMLResponse) as an HTTP-REDIRECT binding
 %%

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -26,7 +26,7 @@
 add_xml_id(Xml) ->
     Xml#xmlElement{attributes = Xml#xmlElement.attributes ++ [
         #xmlAttribute{name = 'ID',
-            value = uuid:to_string(uuid:uuid1()),
+            value = 'a' ++ uuid:to_string(uuid:uuid1()),
             namespace = #xmlNamespace{}}
         ]}.
 

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -26,7 +26,7 @@
 add_xml_id(Xml) ->
     Xml#xmlElement{attributes = Xml#xmlElement.attributes ++ [
         #xmlAttribute{name = 'ID',
-            value = 'a' ++ uuid:to_string(uuid:uuid1()),
+            value = "a" ++ uuid:to_string(uuid:uuid1()),
             namespace = #xmlNamespace{}}
         ]}.
 

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -33,6 +33,7 @@ add_xml_id(Xml) ->
 %% @doc Return an AuthnRequest as an XML element
 -spec generate_authn_request(IdpURL :: string(), esaml:sp()) -> #xmlElement{}.
 generate_authn_request(IdpURL, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
+    erlang:display('Generate authnreq... v1'),
     Now = erlang:localtime_to_universaltime(erlang:localtime()),
     Stamp = esaml_util:datetime_to_saml(Now),
 

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -203,6 +203,7 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
             case xmerl_xpath:string("/samlp:Response/saml:Assertion", X, [{namespace, Ns}]) of
                 [A] -> A;
                 assertion ->
+                  erlang:display('validating assertion'),
                   erlang:display(X),
                   erlang:display(assertion),
                   {error, bad_assertion}

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -33,7 +33,7 @@ add_xml_id(Xml) ->
 %% @doc Return an AuthnRequest as an XML element
 -spec generate_authn_request(IdpURL :: string(), esaml:sp()) -> #xmlElement{}.
 generate_authn_request(IdpURL, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
-    erlang:display("Generate authnreq... v1"),
+    erlang:display("Generate authnreq... v2"),
     Now = erlang:localtime_to_universaltime(erlang:localtime()),
     Stamp = esaml_util:datetime_to_saml(Now),
 

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -201,7 +201,10 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
         fun(X) ->
             case xmerl_xpath:string("/samlp:Response/saml:Assertion", X, [{namespace, Ns}]) of
                 [A] -> A;
-                _ -> {error, bad_assertion}
+                assertion ->
+                  erlang:display(X),
+                  erlang:display(assertion),
+                  {error, bad_assertion}
             end
         end,
         fun(A) ->

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -33,7 +33,7 @@ add_xml_id(Xml) ->
 %% @doc Return an AuthnRequest as an XML element
 -spec generate_authn_request(IdpURL :: string(), esaml:sp()) -> #xmlElement{}.
 generate_authn_request(IdpURL, SP = #esaml_sp{metadata_uri = MetaURI, consume_uri = ConsumeURI}) ->
-    erlang:display('Generate authnreq... v1'),
+    erlang:display("Generate authnreq... v1"),
     Now = erlang:localtime_to_universaltime(erlang:localtime()),
     Stamp = esaml_util:datetime_to_saml(Now),
 
@@ -203,7 +203,7 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
             case xmerl_xpath:string("/samlp:Response/saml:Assertion", X, [{namespace, Ns}]) of
                 [A] -> A;
                 assertion ->
-                  erlang:display('validating assertion'),
+                  erlang:display("validating assertion"),
                   erlang:display(X),
                   erlang:display(assertion),
                   {error, bad_assertion}

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -202,10 +202,10 @@ validate_assertion(Xml, DuplicateFun, SP = #esaml_sp{}) ->
         fun(X) ->
             case xmerl_xpath:string("/samlp:Response/saml:Assertion", X, [{namespace, Ns}]) of
                 [A] -> A;
-                assertion ->
+                Assertion ->
                   erlang:display("validating assertion"),
                   erlang:display(X),
-                  erlang:display(assertion),
+                  erlang:display(Assertion),
                   {error, bad_assertion}
             end
         end,

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -166,7 +166,10 @@ verify(ElementPre, Fingerprints) ->
     DsNs = [{"ds", 'http://www.w3.org/2000/09/xmldsig#'},
         {"ec", 'http://www.w3.org/2001/10/xml-exc-c14n#'}],
     Element = case xmerl_xpath:string("saml2:Assertion", ElementPre, []) of
-        [] -> ElementPre;
+        [] -> case xmerl_xpath:string("Assertion", ElementPre, []) of
+          [] -> ElementPre;
+          [Element4 = #xmlElement{}] -> Element4
+        end;
         [Element3 = #xmlElement{}] -> Element3
     end,
     [#xmlAttribute{value = SignatureMethodAlgorithm}] = xmerl_xpath:string("ds:Signature/ds:SignedInfo/ds:SignatureMethod/@Algorithm", Element, [{namespace, DsNs}]),

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -161,11 +161,14 @@ digest(Element, HashFunction) ->
 %% Will throw badmatch errors if you give it XML that is not signed
 %% according to the xml-dsig spec. If you're using something other
 %% than rsa+sha1 or sha256 this will asplode. Don't say I didn't warn you.
--spec verify(Element :: #xmlElement{}, Fingerprints :: [fingerprint()] | any) -> ok | {error, bad_digest | bad_signature | cert_not_accepted}.
-verify(Element, Fingerprints) ->
+-spec verify(ElementPre :: #xmlElement{}, Fingerprints :: [fingerprint()] | any) -> ok | {error, bad_digest | bad_signature | cert_not_accepted}.
+verify(ElementPre, Fingerprints) ->
     DsNs = [{"ds", 'http://www.w3.org/2000/09/xmldsig#'},
         {"ec", 'http://www.w3.org/2001/10/xml-exc-c14n#'}],
-
+    Element = case xmerl_xpath:string("saml2:Assertion", ElementPre, []) of
+        [] -> ElementPre;
+        [Element3 = #xmlElement{}] -> Element3
+    end,
     [#xmlAttribute{value = SignatureMethodAlgorithm}] = xmerl_xpath:string("ds:Signature/ds:SignedInfo/ds:SignatureMethod/@Algorithm", Element, [{namespace, DsNs}]),
     {HashFunction, _, _} = signature_props(SignatureMethodAlgorithm),
 
@@ -201,7 +204,11 @@ verify(Element, Fingerprints) ->
         CertHash2 = crypto:hash(sha256, CertBin),
 
         Cert = public_key:pkix_decode_cert(CertBin, plain),
-        {_, KeyBin} = Cert#'Certificate'.tbsCertificate#'TBSCertificate'.subjectPublicKeyInfo#'SubjectPublicKeyInfo'.subjectPublicKey,
+        
+        KeyBin = case Cert#'Certificate'.tbsCertificate#'TBSCertificate'.subjectPublicKeyInfo#'SubjectPublicKeyInfo'.subjectPublicKey of
+           {_, KeyBin2} -> KeyBin2;
+           KeyBin3 -> KeyBin3
+        end,
         Key = public_key:pem_entry_decode({'RSAPublicKey', KeyBin, not_encrypted}),
 
         case public_key:verify(Data, HashFunction, Sig, Key) of

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -65,7 +65,7 @@ sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_bin
             case lists:keyfind('id', 2, ElementStrip#xmlElement.attributes) of
                 #xmlAttribute{value = LowId} -> {ElementStrip, LowId};
                 _ ->
-                    NewId = uuid:to_string(uuid:uuid1()),
+                    NewId = 'a' ++ uuid:to_string(uuid:uuid1()),
                     Attr = #xmlAttribute{name = 'ID', value = NewId, namespace = #xmlNamespace{}},
                     NewAttrs = [Attr | ElementStrip#xmlElement.attributes],
                     Elem = ElementStrip#xmlElement{attributes = NewAttrs},
@@ -204,7 +204,7 @@ verify(ElementPre, Fingerprints) ->
         CertHash2 = crypto:hash(sha256, CertBin),
 
         Cert = public_key:pkix_decode_cert(CertBin, plain),
-        
+
         KeyBin = case Cert#'Certificate'.tbsCertificate#'TBSCertificate'.subjectPublicKeyInfo#'SubjectPublicKeyInfo'.subjectPublicKey of
            {_, KeyBin2} -> KeyBin2;
            KeyBin3 -> KeyBin3

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -65,7 +65,7 @@ sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_bin
             case lists:keyfind('id', 2, ElementStrip#xmlElement.attributes) of
                 #xmlAttribute{value = LowId} -> {ElementStrip, LowId};
                 _ ->
-                    NewId = 'a' ++ uuid:to_string(uuid:uuid1()),
+                    NewId = "a" ++ uuid:to_string(uuid:uuid1()),
                     Attr = #xmlAttribute{name = 'ID', value = NewId, namespace = #xmlNamespace{}},
                     NewAttrs = [Attr | ElementStrip#xmlElement.attributes],
                     Elem = ElementStrip#xmlElement{attributes = NewAttrs},


### PR DESCRIPTION
Now the verify function will not break if we get a document back instead of an element

Also subjectPublicKey sometimes does not include a tuple but directly the binary key, so match on that as well
