### PR TITLE
Fix SP example app.

### DIFF
--- a/examples/sp/rebar.config
+++ b/examples/sp/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
     {esaml, ".*", {git, "git://github.com/arekinath/esaml", "HEAD"}},
-    {cowboy, ".*", {git, "git://github.com/extend/cowboy", "HEAD"}}
+    {cowboy, ".*", {git, "git://github.com/extend/cowboy", {branch, "1.1.x"}}}
 ]}.


### PR DESCRIPTION
Cowboy 2 removes the http_start function. Cowboy 1.1.x has the http_start function. Let's use that instead.